### PR TITLE
fix: profile page was not loading if treasury had no tokens;

### DIFF
--- a/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberTokens.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberTokens.tsx
@@ -44,7 +44,7 @@ export const MemberTokens = ({ daoChain, dao, member }: MemberTokensProps) => {
   }, [dao]);
 
   const tableData: TokenTableType[] | null = useMemo(() => {
-    if (dao && member && treasury) {
+    if (dao && member && treasury && treasury.tokenBalances) {
       return treasury.tokenBalances
         .filter((bal) => Number(bal.balance))
         .map((bal) => {


### PR DESCRIPTION
## GitHub Issue

https://github.com/polux0/DAOHaus/issues/3

## Changes

In MemberToken.ts:
dao && member && treasury line 
became dao && member && treasury && treasury.tokenBalances
as treasury can hold no tokens and that should not prevent page from loading 

## Packages Added

X

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
